### PR TITLE
Updating storage example

### DIFF
--- a/examples/storagetests.py
+++ b/examples/storagetests.py
@@ -60,6 +60,10 @@ print('Storage account keys...')
 keys = azurerm.get_storage_account_keys(access_token, subscription_id, resource_group, saname)
 print(keys.text)
 
+# Get just the primary access key. For the secondary access key, use [1] instead of [0]
+primarykey = json.loads(keys.text)
+print(primarykey['keys'][0]['value'])
+
 # delete storage_account
 #print('Press Enter to delete account.')
 #input()


### PR DESCRIPTION
Adding logic to parse out just the primary (or secondary) access key for a storage account. This is what you'd likely need for a given storage account to actually make a connection and create, retrieve, or delete storage resources.

Need to use `json.load` rather than `json.dumps` as in other examples, so may not be intuitive at first glance. Could probably do this without declaring `primarykey` to make it a one-liner.