### PR TITLE
Adding unit tests for Cosmos DB RP

### DIFF
--- a/azurerm/cosmosdbrp.py
+++ b/azurerm/cosmosdbrp.py
@@ -1,4 +1,4 @@
-'''cosmosdbrp.py - azurerm functions for the Microsoft.Storage resource provider'''
+'''cosmosdbrp.py - azurerm functions for the Microsoft.DocumentDB resource provider'''
 import json
 
 from .restfns import do_post, do_put
@@ -7,7 +7,7 @@ from .settings import COSMOSDB_API, get_rm_endpoint
 
 def create_cosmosdb_account(access_token, subscription_id, rgname, account_name, location,
                             cosmosdb_kind):
-    '''Create a new storage account in the named resource group, with the named location.
+    '''Create a new Cosmos DB account in the named resource group, with the named location.
 
     Args:
         access_token (str): A valid Azure authentication token.

--- a/test/cosmosdb_test.py
+++ b/test/cosmosdb_test.py
@@ -1,0 +1,53 @@
+# azurerm unit tests - Cosmos DB
+# to run tests: python -m unittest cosmosdb_test.py
+
+import sys
+import unittest
+from haikunator import Haikunator
+import json
+import azurerm
+
+class TestAzurermPy(unittest.TestCase):
+
+    def setUp(self):
+        # Load Azure app defaults
+        try:
+            with open('azurermconfig.json') as configFile:
+                configData = json.load(configFile)
+        except FileNotFoundError:
+            print("Error: Expecting azurermconfig.json in current folder")
+            sys.exit()
+        tenant_id = configData['tenantId']
+        app_id = configData['appId']
+        app_secret = configData['appSecret']
+        self.subscription_id = configData['subscriptionId']
+        self.access_token = azurerm.get_access_token(tenant_id, app_id, app_secret)
+        self.location = configData['location']
+        h = Haikunator()
+        self.rgname = h.haikunate()
+        self.cosmosdbname = h.haikunate()
+
+    def tearDown(self):
+        pass
+
+    def test_resource_groups(self):
+        # create resource group
+        print('Creating resource group: ' + self.rgname)
+        response = azurerm.create_resource_group(self.access_token, self.subscription_id, \
+            self.rgname, self.location)
+        self.assertEqual(response.status_code, 201)
+
+        # Create Cosmos DB account
+        print('Creating Cosmos DB account: ' + self.cosmosdbname)
+
+        response = azurerm.create_cosmosdb_account(self.access_token, self.subscription_id, self.rgname, \
+            self.cosmosdbname, self.location, cosmosdb_kind='GlobalDocumentDB')
+        self.assertEqual(response.status_code, 200)
+
+        # delete resource group
+        print('Deleting resource group: ' + self.rgname)
+        response = azurerm.delete_resource_group(self.access_token, self.subscription_id, self.rgname)
+        self.assertEqual(response.status_code, 202)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Yes, it's basic. The request to create the Cosmos DB account (should) return a 200 within a few seconds, but the Azure platform then takes 2-3 minutes to initialize the account before you could query it to obtain the access keys. 

You could sleep the tests for 150 seconds (I've found works well), and then test `get_cosmosdb_account_keys` if desired. I can update `test/cosmosdb_test.py` to do this if needed, but that holds up the tests from completing.